### PR TITLE
docs: fix jsdoc is not applied for overloading methods

### DIFF
--- a/src/Component.ts
+++ b/src/Component.ts
@@ -91,6 +91,8 @@ class Component<T extends EventMap = EventMap> {
     this._eventHandler = {};
   }
 
+  public trigger<K extends EventKey<T>>(eventName: EventNoParamKey<T, K>): boolean;
+  public trigger<K extends EventKey<T>>(eventName: K, customEvent: FirstParam<T, K>, ...restParam: RestParam<T, K>): boolean;
   /**
    * Triggers a custom event.
    * @ko 커스텀 이벤트를 발생시킨다
@@ -119,8 +121,6 @@ class Component<T extends EventMap = EventMap> {
    * // If you want to more know event design. You can see article.
    * // https://github.com/naver/egjs-component/wiki/How-to-make-Component-event-design%3F
    */
-  public trigger<K extends EventKey<T>>(eventName: EventNoParamKey<T, K>): boolean;
-  public trigger<K extends EventKey<T>>(eventName: K, customEvent: FirstParam<T, K>, ...restParam: RestParam<T, K>): boolean;
   public trigger<K extends EventKey<T>>(eventName: K, customEvent?: FirstParam<T, K>, ...restParam: any[]): boolean {
     let handlerList = this._eventHandler[eventName] || [];
     const hasHandlerList = handlerList.length > 0;
@@ -155,6 +155,8 @@ class Component<T extends EventMap = EventMap> {
     return !isCanceled;
   }
 
+  public once<K extends EventKey<T>>(eventName: K, handlerToAttach: EventCallback<T, K, this>): this;
+  public once(eventHash: EventHash<T, this>): this;
   /**
    * Executed event just one time.
    * @ko 이벤트가 한번만 실행된다.
@@ -178,8 +180,6 @@ class Component<T extends EventMap = EventMap> {
    * some.trigger("hi");
    * // Nothing happens
    */
-  public once<K extends EventKey<T>>(eventName: K, handlerToAttach: EventCallback<T, K, this>): this;
-  public once(eventHash: EventHash<T, this>): this;
   public once<K extends EventKey<T>>(eventName: K | EventHash<T, this>, handlerToAttach?: EventCallback<T, K, this>): this {
     if (typeof eventName === "object" && isUndefined(handlerToAttach)) {
       const eventHash = eventName;
@@ -216,6 +216,8 @@ class Component<T extends EventMap = EventMap> {
     return !!this._eventHandler[eventName];
   }
 
+  public on<K extends EventKey<T>>(eventName: K, handlerToAttach: EventCallback<T, K, this>): this;
+  public on(eventHash: EventHash<T, this>): this;
   /**
    * Attaches an event to a component.
    * @ko 컴포넌트에 이벤트를 등록한다.
@@ -232,8 +234,6 @@ class Component<T extends EventMap = EventMap> {
    *   }
    * }
    */
-  public on<K extends EventKey<T>>(eventName: K, handlerToAttach: EventCallback<T, K, this>): this;
-  public on(eventHash: EventHash<T, this>): this;
   public on<K extends EventKey<T>>(eventName: K | EventHash<T, this>, handlerToAttach?: EventCallback<T, K, this>): this {
     if (typeof eventName === "object" && isUndefined(handlerToAttach)) {
       const eventHash = eventName;
@@ -258,6 +258,8 @@ class Component<T extends EventMap = EventMap> {
     return this;
   }
 
+  public off(eventHash?: EventHash<T, this>): this;
+  public off<K extends EventKey<T>>(eventName: K, handlerToDetach?: EventCallback<T, K, this>): this;
   /**
    * Detaches an event from the component.
    * @ko 컴포넌트에 등록된 이벤트를 해제한다
@@ -274,8 +276,6 @@ class Component<T extends EventMap = EventMap> {
    *   }
    * }
    */
-  public off(eventHash?: EventHash<T, this>): this;
-  public off<K extends EventKey<T>>(eventName: K, handlerToDetach?: EventCallback<T, K, this>): this;
   public off<K extends EventKey<T>>(eventName?: K | EventHash<T, this>, handlerToDetach?: EventCallback<T, K, this>): this {
     // Detach all event handlers.
     if (isUndefined(eventName)) {

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -24,6 +24,7 @@ type EventWithRestParam = ((evt: NotFunction, ...restParam: any[]) => any);
  * Types that can be used when attaching new event definition as generic on a class
  * @ko 클래스 타입 등록시 사용가능한 타입
  * @example
+ * ```
  * new SomeClass<{
  *   // Using it as object
  *   evt0: {
@@ -36,6 +37,7 @@ type EventWithRestParam = ((evt: NotFunction, ...restParam: any[]) => any);
  *     param1: string
  *   }, arg1: string, arg2: boolean) => boolean;
  * }>
+ * ```
  */
 type EventDefinition = NotFunction | NoArguments | EventWithRestParam;
 
@@ -71,7 +73,6 @@ class Component<T extends EventMap = EventMap> {
    * @ko 버전정보 문자열
    * @name VERSION
    * @static
-   * @type {String}
    * @example
    * eg.Component.VERSION;  // ex) 2.0.0
    * @memberof eg.Component
@@ -80,6 +81,7 @@ class Component<T extends EventMap = EventMap> {
 
   /**
    * @deprecated
+   * @private
    */
   public options: {[key: string]: any} = {};
   private _eventHandler: {[keys: string]: EventCallback<T, EventKey<T>, Component<T>>[]};
@@ -96,10 +98,12 @@ class Component<T extends EventMap = EventMap> {
   /**
    * Triggers a custom event.
    * @ko 커스텀 이벤트를 발생시킨다
-   * @param {String} eventName The name of the custom event to be triggered <ko>발생할 커스텀 이벤트의 이름</ko>
-   * @param {Object} customEvent Event data to be sent when triggering a custom event <ko>커스텀 이벤트가 발생할 때 전달할 데이터</ko>
-   * @return {Boolean} Indicates whether the event has occurred. If the stop() method is called by a custom event handler, it will return false and prevent the event from occurring. <a href="https://github.com/naver/egjs-component/wiki/How-to-make-Component-event-design%3F">Ref</a> <ko>이벤트 발생 여부. 커스텀 이벤트 핸들러에서 stop() 메서드를 호출하면 'false'를 반환하고 이벤트 발생을 중단한다. <a href="https://github.com/naver/egjs-component/wiki/How-to-make-Component-event-design%3F">참고</a></ko>
+   * @param {string} eventName The name of the custom event to be triggered <ko>발생할 커스텀 이벤트의 이름</ko>
+   * @param {object} customEvent Event data to be sent when triggering a custom event <ko>커스텀 이벤트가 발생할 때 전달할 데이터</ko>
+   * @param {any[]} restParam Additional parameters when triggering a custom event <ko>커스텀 이벤트가 발생할 때 필요시 추가적으로 전달할 데이터</ko>
+   * @return Indicates whether the event has occurred. If the stop() method is called by a custom event handler, it will return false and prevent the event from occurring. <a href="https://github.com/naver/egjs-component/wiki/How-to-make-Component-event-design%3F">Ref</a> <ko>이벤트 발생 여부. 커스텀 이벤트 핸들러에서 stop() 메서드를 호출하면 'false'를 반환하고 이벤트 발생을 중단한다. <a href="https://github.com/naver/egjs-component/wiki/How-to-make-Component-event-design%3F">참고</a></ko>
    * @example
+   * ```
    * class Some extends eg.Component {
    *   some(){
    *     if(this.trigger("beforeHi")){ // When event call to stop return false.
@@ -120,6 +124,7 @@ class Component<T extends EventMap = EventMap> {
    * });
    * // If you want to more know event design. You can see article.
    * // https://github.com/naver/egjs-component/wiki/How-to-make-Component-event-design%3F
+   * ```
    */
   public trigger<K extends EventKey<T>>(eventName: K, customEvent?: FirstParam<T, K>, ...restParam: any[]): boolean {
     let handlerList = this._eventHandler[eventName] || [];
@@ -160,17 +165,17 @@ class Component<T extends EventMap = EventMap> {
   /**
    * Executed event just one time.
    * @ko 이벤트가 한번만 실행된다.
-   * @param {eventName} eventName The name of the event to be attached <ko>등록할 이벤트의 이름</ko>
-   * @param {Function} handlerToAttach The handler function of the event to be attached <ko>등록할 이벤트의 핸들러 함수</ko>
-   * @return {eg.Component} An instance of a component itself<ko>컴포넌트 자신의 인스턴스</ko>
+   * @param {string} eventName The name of the event to be attached <ko>등록할 이벤트의 이름</ko>
+   * @param {function} handlerToAttach The handler function of the event to be attached <ko>등록할 이벤트의 핸들러 함수</ko>
+   * @return An instance of a component itself<ko>컴포넌트 자신의 인스턴스</ko>
    * @example
+   * ```
    * class Some extends eg.Component {
    * hi() {
    *   alert("hi");
    * }
    * thing() {
    *   this.once("hi", this.hi);
-   * }
    * }
    *
    * var some = new Some();
@@ -179,6 +184,7 @@ class Component<T extends EventMap = EventMap> {
    * // fire alert("hi");
    * some.trigger("hi");
    * // Nothing happens
+   * ```
    */
   public once<K extends EventKey<T>>(eventName: K | EventHash<T, this>, handlerToAttach?: EventCallback<T, K, this>): this {
     if (typeof eventName === "object" && isUndefined(handlerToAttach)) {
@@ -203,14 +209,16 @@ class Component<T extends EventMap = EventMap> {
   /**
    * Checks whether an event has been attached to a component.
    * @ko 컴포넌트에 이벤트가 등록됐는지 확인한다.
-   * @param {String} eventName The name of the event to be attached <ko>등록 여부를 확인할 이벤트의 이름</ko>
-   * @return {Boolean} Indicates whether the event is attached. <ko>이벤트 등록 여부</ko>
+   * @param {string} eventName The name of the event to be attached <ko>등록 여부를 확인할 이벤트의 이름</ko>
+   * @return {boolean} Indicates whether the event is attached. <ko>이벤트 등록 여부</ko>
    * @example
+   * ```
    * class Some extends eg.Component {
    *   some() {
    *     this.hasOn("hi");// check hi event.
    *   }
    * }
+   * ```
    */
   public hasOn<K extends EventKey<T>>(eventName: K): boolean {
     return !!this._eventHandler[eventName];
@@ -221,10 +229,11 @@ class Component<T extends EventMap = EventMap> {
   /**
    * Attaches an event to a component.
    * @ko 컴포넌트에 이벤트를 등록한다.
-   * @param {eventName} eventName The name of the event to be attached <ko>등록할 이벤트의 이름</ko>
-   * @param {Function} handlerToAttach The handler function of the event to be attached <ko>등록할 이벤트의 핸들러 함수</ko>
-   * @return {eg.Component} An instance of a component itself<ko>컴포넌트 자신의 인스턴스</ko>
+   * @param {string} eventName The name of the event to be attached <ko>등록할 이벤트의 이름</ko>
+   * @param {function} handlerToAttach The handler function of the event to be attached <ko>등록할 이벤트의 핸들러 함수</ko>
+   * @return An instance of a component itself<ko>컴포넌트 자신의 인스턴스</ko>
    * @example
+   * ```
    * class Some extends eg.Component {
    *   hi() {
    *     console.log("hi");
@@ -233,6 +242,7 @@ class Component<T extends EventMap = EventMap> {
    *     this.on("hi",this.hi); //attach event
    *   }
    * }
+   * ```
    */
   public on<K extends EventKey<T>>(eventName: K | EventHash<T, this>, handlerToAttach?: EventCallback<T, K, this>): this {
     if (typeof eventName === "object" && isUndefined(handlerToAttach)) {
@@ -263,10 +273,11 @@ class Component<T extends EventMap = EventMap> {
   /**
    * Detaches an event from the component.
    * @ko 컴포넌트에 등록된 이벤트를 해제한다
-   * @param {eventName} eventName The name of the event to be detached <ko>해제할 이벤트의 이름</ko>
-   * @param {Function} handlerToDetach The handler function of the event to be detached <ko>해제할 이벤트의 핸들러 함수</ko>
-   * @return {eg.Component} An instance of a component itself <ko>컴포넌트 자신의 인스턴스</ko>
+   * @param {string} eventName The name of the event to be detached <ko>해제할 이벤트의 이름</ko>
+   * @param {function} handlerToDetach The handler function of the event to be detached <ko>해제할 이벤트의 핸들러 함수</ko>
+   * @return An instance of a component itself <ko>컴포넌트 자신의 인스턴스</ko>
    * @example
+   * ```
    * class Some extends eg.Component {
    *   hi() {
    *     console.log("hi");
@@ -275,6 +286,7 @@ class Component<T extends EventMap = EventMap> {
    *     this.off("hi",this.hi); //detach event
    *   }
    * }
+   * ```
    */
   public off<K extends EventKey<T>>(eventName?: K | EventHash<T, this>, handlerToDetach?: EventCallback<T, K, this>): this {
     // Detach all event handlers.


### PR DESCRIPTION
## Details
tl;dr;

> before
![image](https://user-images.githubusercontent.com/26213435/95953471-d041e600-0e34-11eb-9283-275a084f48bd.png)

> after
![image](https://user-images.githubusercontent.com/26213435/95953392-b6080800-0e34-11eb-9497-5ce9b1679d18.png)
