### PR TITLE
fix: prevent triggering event that not defined

### DIFF
--- a/src/Component.ts
+++ b/src/Component.ts
@@ -62,12 +62,16 @@ type RestParam<T extends EventMap, K extends EventKey<T>>
     ? U
     : void[]
 
+interface DefaultEventMap {
+  [key: string]: { [key: string]: any } | void;
+}
+
 /**
  * A class used to manage events in a component
  * @ko 컴포넌트의 이벤트을 관리할 수 있게 하는 클래스
  * @alias eg.Component
  */
-class Component<T extends EventMap = {}> {
+class Component<T extends EventMap = DefaultEventMap> {
   /**
    * Version info string
    * @ko 버전정보 문자열

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -67,7 +67,7 @@ type RestParam<T extends EventMap, K extends EventKey<T>>
  * @ko 컴포넌트의 이벤트을 관리할 수 있게 하는 클래스
  * @alias eg.Component
  */
-class Component<T extends EventMap = EventMap> {
+class Component<T extends EventMap = {}> {
   /**
    * Version info string
    * @ko 버전정보 문자열

--- a/test/types/Component.test-d.ts
+++ b/test/types/Component.test-d.ts
@@ -217,6 +217,36 @@ test("Wrong event definitions", () => {
   }> {};
 });
 
+test("Should show error when calling method with not defined event name", () => {
+  class NotDefinedClass extends Component {};
+
+  // $ExpectError
+  new NotDefinedClass().trigger("a");
+
+  // $ExpectError
+  new NotDefinedClass().on("a", e => {});
+
+  // $ExpectError
+  new NotDefinedClass().once("a", e => {});
+
+  // $ExpectError
+  new NotDefinedClass().off("a", e => {});
+
+  class NotDefinedClass2 extends Component<{ b: { prop: number } }> {};
+
+  // $ExpectError
+  new NotDefinedClass2().trigger("a");
+
+  // $ExpectError
+  new NotDefinedClass2().on("a", e => {});
+
+  // $ExpectError
+  new NotDefinedClass2().once("a", e => {});
+
+  // $ExpectError
+  new NotDefinedClass2().off("a", e => {});
+});
+
 test("Wrong trigger() usage", () => {
   // $ExpectError
   component.trigger();

--- a/test/types/Component.test-d.ts
+++ b/test/types/Component.test-d.ts
@@ -46,11 +46,27 @@ test("Correct event definitions", () => {
   }> {};
 });
 
-test("Can make component with no events", () => {
+test("Can make component with no event definitions", () => {
   // $ExpectType SomeCorrectClass
   class SomeCorrectClass extends Component {
     // NOTHING
   }
+});
+
+test("Can make component with no event definitions and call methods of it", () => {
+  class SomeCorrectClass2 extends Component {};
+
+  // $ExpectType boolean
+  new SomeCorrectClass2().trigger("a");
+
+  // $ExpectType SomeCorrectClass2
+  new SomeCorrectClass2().on("a", e => {});
+
+  // $ExpectType SomeCorrectClass2
+  new SomeCorrectClass2().once("a", e => {});
+
+  // $ExpectType SomeCorrectClass2
+  new SomeCorrectClass2().off("a", e => {});
 });
 
 test("Correct trigger() usage", () => {
@@ -218,7 +234,7 @@ test("Wrong event definitions", () => {
 });
 
 test("Should show error when calling method with not defined event name", () => {
-  class NotDefinedClass extends Component {};
+  class NotDefinedClass extends Component<{ b: { prop: number } }> {};
 
   // $ExpectError
   new NotDefinedClass().trigger("a");
@@ -231,20 +247,6 @@ test("Should show error when calling method with not defined event name", () => 
 
   // $ExpectError
   new NotDefinedClass().off("a", e => {});
-
-  class NotDefinedClass2 extends Component<{ b: { prop: number } }> {};
-
-  // $ExpectError
-  new NotDefinedClass2().trigger("a");
-
-  // $ExpectError
-  new NotDefinedClass2().on("a", e => {});
-
-  // $ExpectError
-  new NotDefinedClass2().once("a", e => {});
-
-  // $ExpectError
-  new NotDefinedClass2().off("a", e => {});
 });
 
 test("Wrong trigger() usage", () => {


### PR DESCRIPTION
## Details
This prevents components from triggering events that not defined.
> Before
```ts
// This was okay
  class NotDefinedClass extends Component {};
  // ✔
  new NotDefinedClass().trigger("a");
  new NotDefinedClass().on("a", e => {});
  new NotDefinedClass().once("a", e => {});
  new NotDefinedClass().off("a", e => {});
```

> After
```ts
// This will show error
  class NotDefinedClass extends Component {};
  // ❌
  new NotDefinedClass().trigger("a");
  new NotDefinedClass().on("a", e => {});
  new NotDefinedClass().once("a", e => {});
  new NotDefinedClass().off("a", e => {});

// This is okay
  class NotDefinedClass extends Component<{ a: void }> {};
  // ✔
  new NotDefinedClass().trigger("a");
  new NotDefinedClass().on("a", e => {});
  new NotDefinedClass().once("a", e => {});
  new NotDefinedClass().off("a", e => {});
```