### PR TITLE
fix: fix default, trigger, on types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@egjs/component",
-	"version": "2.2.0",
+	"version": "2.2.1-snapshot",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -62,7 +62,7 @@ type EventTriggerPartialFunction<F, R extends any[]>
   : (firstParam: EventTriggerFirstParam<F>, ...restParams: R) => any
 
 
-  type EventTriggerFunction<T extends (...params: any[]) => any>
+type EventTriggerFunction<T extends (...params: any[]) => any>
   = T extends (firstParam: infer F, ...restParams: infer R) => any
   ? EventTriggerPartialFunction<F, R>
   : (firstParam?: { [key: string]: never }) => any;
@@ -74,9 +74,9 @@ type EventTriggerNoFunction<T>
 
 // You don't need to include defaultProps in the trigger method's first parameter.
 type EventTriggerParams<T extends EventMap, K extends EventKey<T>>
-= Parameters<T[K] extends (...params: any[]) => any
-  ? EventTriggerFunction<T[K]>
-  : EventTriggerNoFunction<T[K]>>;
+  = Parameters<T[K] extends (...params: any[]) => any
+    ? EventTriggerFunction<T[K]>
+    : EventTriggerNoFunction<T[K]>>;
 
 
 

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -4,7 +4,7 @@
  */
 
 function isUndefined(value: any): boolean {
-    return typeof value === "undefined";
+  return typeof value === "undefined";
 }
 
 interface DefaultProps<T> {
@@ -12,10 +12,6 @@ interface DefaultProps<T> {
   stop: () => void;
   currentTarget: T;
 }
-
-type EventNoParamKey<T extends EventMap, K extends EventKey<T>> = T[K] extends NoArguments
-  ? K
-  : never;
 type NotFunction = { [k: string]: unknown } & ({ bind?: never } | { call?: never });
 type NoArguments = undefined | null | void | never;
 type EventWithRestParam = ((evt: NotFunction, ...restParam: any[]) => any);
@@ -45,25 +41,45 @@ type EventMap = Record<string, EventDefinition>;
 type EventKey<T extends EventMap> = string & keyof T;
 type EventHash<T extends EventMap, S> = Partial<{ [K in EventKey<T>]: EventCallback<T, K, S> }>;
 
+
+// In the on and once methods, the defaultProps must be included in the first parameter.
 type EventCallback<T extends EventMap, K extends EventKey<T>, S>
-  = T[K] extends NoArguments
-    ? (event: DefaultProps<S>) => any
-    : T[K] extends (evt: infer U, ...restParam: infer V) => any
-      ? (event: U & DefaultProps<S>, ...restParam: V) => any
-      : (event: T[K] & DefaultProps<S>) => any;
-type FirstParam<T extends EventMap, K extends EventKey<T>>
-  = T[K] extends NoArguments
-    ? void
-    : T[K] extends (evt: infer U, ...restParam: any[]) => any
-      ? U
-      : T[K];
-type RestParam<T extends EventMap, K extends EventKey<T>>
-  = T[K] extends (evt: NotFunction, ...restParam: infer U) => any
-    ? U
-    : void[]
+  = T[K] extends (...params: any[]) => any
+  ? EventCallbackFunction<T[K], S>
+  : (event: EventCallbackFirstParam<T[K], S>) => any;
+
+type EventCallbackFirstParam<P, S> = P extends NoArguments ? DefaultProps<S> : P & DefaultProps<S>;
+type EventCallbackFunction<T extends (...params: any[]) => any, S>
+  = T extends (firstParam?: infer F, ...restParams: infer R) => any
+  ? (firstParam: EventCallbackFirstParam<Required<F>, S>, ...restParams: R) => any
+  : (firstParam: DefaultProps<S>) => any;
+
+
+
+// You don't need to include defaultProps in the trigger method's first parameter.
+type EventTriggerParams<T extends EventMap, K extends EventKey<T>>
+= Parameters<T[K] extends (...params: any[]) => any
+  ? EventTriggerFunction<T[K]>
+  : EventTriggerNoFunction<T[K]>>;
+
+type EventTriggerFirstParam<T> = (T extends {} ? Pick<T, Exclude<keyof T, keyof DefaultProps<any>>> : { [key: string]: never }) & Partial<DefaultProps<any>>;
+type EventTriggerPartialFunction<F, R extends any[]>
+  = Required<F> extends F
+  ? (firstParam?: EventTriggerFirstParam<F>, ...restParams: R) => any
+  : (firstParam: EventTriggerFirstParam<F>, ...restParams: R) => any;
+type EventTriggerFunction<T extends (...params: any[]) => any>
+  = T extends (firstParam: infer F, ...restParams: infer R) => any
+  ? EventTriggerPartialFunction<F, R>
+  : (firstParam?: { [key: string]: never }) => any;
+
+type EventTriggerNoFunction<T>
+  = T extends NoArguments
+  ? (firstParam?: { [key: string]: never }) => any
+  : EventTriggerFunction<(fisrtParam: EventTriggerFirstParam<T>) => any>;
+
 
 interface DefaultEventMap {
-  [key: string]: { [key: string]: any } | void;
+  [key: string]: (firstParam?: { [key: string]: any }, ...restParams: any[]) => any;
 }
 
 /**
@@ -87,8 +103,8 @@ class Component<T extends EventMap = DefaultEventMap> {
    * @deprecated
    * @private
    */
-  public options: {[key: string]: any} = {};
-  private _eventHandler: {[keys: string]: EventCallback<T, EventKey<T>, Component<T>>[]};
+  public options: { [key: string]: any } = {};
+  private _eventHandler: { [keys: string]: EventCallback<T, EventKey<T>, Component<T>>[] };
 
   /**
    * @support {"ie": "7+", "ch" : "latest", "ff" : "latest",  "sf" : "latest", "edge" : "latest", "ios" : "7+", "an" : "2.1+ (except 3.x)"}
@@ -97,8 +113,7 @@ class Component<T extends EventMap = DefaultEventMap> {
     this._eventHandler = {};
   }
 
-  public trigger<K extends EventKey<T>>(eventName: EventNoParamKey<T, K>): boolean;
-  public trigger<K extends EventKey<T>>(eventName: K, customEvent: FirstParam<T, K>, ...restParam: RestParam<T, K>): boolean;
+  public trigger<K extends EventKey<T>>(eventName: K, ...params: EventTriggerParams<T, K>): boolean;
   /**
    * Triggers a custom event.
    * @ko 커스텀 이벤트를 발생시킨다
@@ -130,16 +145,15 @@ class Component<T extends EventMap = DefaultEventMap> {
    * // https://github.com/naver/egjs-component/wiki/How-to-make-Component-event-design%3F
    * ```
    */
-  public trigger<K extends EventKey<T>>(eventName: K, customEvent?: FirstParam<T, K>, ...restParam: any[]): boolean {
+  public trigger<K extends EventKey<T>>(eventName: K, ...params: any[]): boolean {
     let handlerList = this._eventHandler[eventName] || [];
     const hasHandlerList = handlerList.length > 0;
 
     if (!hasHandlerList) {
       return true;
     }
-    if (!customEvent) {
-      customEvent = {} as any;
-    }
+    const customEvent = params[0] || {};
+    const restParams = params.slice(1);
 
     // If detach method call in handler in first time then handler list calls.
     handlerList = handlerList.concat();
@@ -153,8 +167,8 @@ class Component<T extends EventMap = DefaultEventMap> {
 
     let arg: any[] = [customEvent];
 
-    if (restParam.length >= 1) {
-      arg = arg.concat(restParam);
+    if (restParams.length >= 1) {
+      arg = arg.concat(restParams);
     }
 
     handlerList.forEach(handler => {

--- a/src/Component.ts
+++ b/src/Component.ts
@@ -42,12 +42,6 @@ type EventKey<T extends EventMap> = string & keyof T;
 type EventHash<T extends EventMap, S> = Partial<{ [K in EventKey<T>]: EventCallback<T, K, S> }>;
 
 
-// In the on and once methods, the defaultProps must be included in the first parameter.
-type EventCallback<T extends EventMap, K extends EventKey<T>, S>
-  = T[K] extends (...params: any[]) => any
-  ? EventCallbackFunction<T[K], S>
-  : (event: EventCallbackFirstParam<T[K], S>) => any;
-
 type EventCallbackFirstParam<P, S> = P extends NoArguments ? DefaultProps<S> : P & DefaultProps<S>;
 type EventCallbackFunction<T extends (...params: any[]) => any, S>
   = T extends (firstParam?: infer F, ...restParams: infer R) => any
@@ -55,19 +49,20 @@ type EventCallbackFunction<T extends (...params: any[]) => any, S>
   : (firstParam: DefaultProps<S>) => any;
 
 
+// In the on and once methods, the defaultProps must be included in the first parameter.
+type EventCallback<T extends EventMap, K extends EventKey<T>, S>
+  = T[K] extends (...params: any[]) => any
+  ? EventCallbackFunction<T[K], S>
+  : (event: EventCallbackFirstParam<T[K], S>) => any;
 
-// You don't need to include defaultProps in the trigger method's first parameter.
-type EventTriggerParams<T extends EventMap, K extends EventKey<T>>
-= Parameters<T[K] extends (...params: any[]) => any
-  ? EventTriggerFunction<T[K]>
-  : EventTriggerNoFunction<T[K]>>;
-
-type EventTriggerFirstParam<T> = (T extends {} ? Pick<T, Exclude<keyof T, keyof DefaultProps<any>>> : { [key: string]: never }) & Partial<DefaultProps<any>>;
+type EventTriggerFirstParam<T extends {}> = Pick<T, Exclude<keyof T, keyof DefaultProps<any>>> & Partial<DefaultProps<any>>;
 type EventTriggerPartialFunction<F, R extends any[]>
-  = Required<F> extends F
+  = F extends undefined
   ? (firstParam?: EventTriggerFirstParam<F>, ...restParams: R) => any
-  : (firstParam: EventTriggerFirstParam<F>, ...restParams: R) => any;
-type EventTriggerFunction<T extends (...params: any[]) => any>
+  : (firstParam: EventTriggerFirstParam<F>, ...restParams: R) => any
+
+
+  type EventTriggerFunction<T extends (...params: any[]) => any>
   = T extends (firstParam: infer F, ...restParams: infer R) => any
   ? EventTriggerPartialFunction<F, R>
   : (firstParam?: { [key: string]: never }) => any;
@@ -76,6 +71,13 @@ type EventTriggerNoFunction<T>
   = T extends NoArguments
   ? (firstParam?: { [key: string]: never }) => any
   : EventTriggerFunction<(fisrtParam: EventTriggerFirstParam<T>) => any>;
+
+// You don't need to include defaultProps in the trigger method's first parameter.
+type EventTriggerParams<T extends EventMap, K extends EventKey<T>>
+= Parameters<T[K] extends (...params: any[]) => any
+  ? EventTriggerFunction<T[K]>
+  : EventTriggerNoFunction<T[K]>>;
+
 
 
 interface DefaultEventMap {

--- a/test/types/Component.test-d.ts
+++ b/test/types/Component.test-d.ts
@@ -112,6 +112,7 @@ test("Even if the event type is not set, there is no type error.", () => {
 
   // Any parameters passes.
   defaultComponent.trigger("a");
+  defaultComponent.trigger("a", {});
   defaultComponent.trigger("a", { a: 1 });
   defaultComponent.trigger("a", { a: 1 }, 1);
 });

--- a/test/types/Component.test-d.ts
+++ b/test/types/Component.test-d.ts
@@ -1,4 +1,4 @@
-import Component from ".";
+import Component from "../../src/Component";
 
 const test = (testName: string, func: (...args: any[]) => any) => {}
 
@@ -13,6 +13,10 @@ class TestClass extends Component<{
     c: boolean;
   }) => any;
   evt4: void;
+  evt5: {
+    a: 1;
+    stop(): void;
+  }
 }> {
   testMethod() {}
 };
@@ -43,6 +47,10 @@ test("Correct event definitions", () => {
     evt5: null;
     evt6: undefined;
     evt7: never;
+    evt8: {
+      a: 1,
+      stop(): void,
+    }
   }> {};
 });
 
@@ -81,8 +89,29 @@ test("Correct trigger() usage", () => {
 
   // $ExpectType boolean
   component.trigger("evt4");
-});
 
+  // skip stop function
+  // $ExpectType boolean
+  component.trigger("evt5", {
+    a: 1,
+  });
+});
+test("Even if the event type is not set, there is no type error.", () => {
+  const defaultComponent = new Component();
+
+  // Any event passes.
+  defaultComponent.on("a", e => {
+    // $ExpectType any
+    e.a;
+    // $ExpectType any
+    e.b;
+  });
+
+  // Any parameters passes.
+  defaultComponent.trigger("a");
+  defaultComponent.trigger("a", { a: 1 });
+  defaultComponent.trigger("a", { a: 1 }, 1);
+});
 test("Correct on, once usage", () => {
   ["on", "once"].forEach((method: "on" | "once") => {
     // $ExpectType TestClass

--- a/test/types/Component.test-d.ts
+++ b/test/types/Component.test-d.ts
@@ -90,6 +90,9 @@ test("Correct trigger() usage", () => {
   // $ExpectType boolean
   component.trigger("evt4");
 
+  // $ExpectType boolean
+  component.trigger("evt4", {});
+
   // skip stop function
   // $ExpectType boolean
   component.trigger("evt5", {

--- a/test/types/Component.test-d.ts
+++ b/test/types/Component.test-d.ts
@@ -108,12 +108,22 @@ test("Even if the event type is not set, there is no type error.", () => {
     e.a;
     // $ExpectType any
     e.b;
+    // $ExpectType Component<DefaultEventMap>
+    e.currentTarget
+    // $ExpectType string
+    e.eventType
+    // $ExpectType () => void
+    e.stop
   });
 
   // Any parameters passes.
+  // $ExpectType boolean
   defaultComponent.trigger("a");
+  // $ExpectType boolean
   defaultComponent.trigger("a", {});
+  // $ExpectType boolean
   defaultComponent.trigger("a", { a: 1 });
+  // $ExpectType boolean
   defaultComponent.trigger("a", { a: 1 }, 1);
 });
 test("Correct on, once usage", () => {


### PR DESCRIPTION
## Issue
<!-- #ISSUE_NUMBER (reference issue number for this PR) -->


1. In the trigger method, you do not need to include the stop function (keyof defaultProps).
2. An error occurs when the default type is void.
3. The default type allows all properties.
4. If the type is {}, it can be used for the second parameter in trigger method.

## Details
<!-- Detailed description of the change/feature -->
