### PR TITLE
chore: add files field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,11 @@
 		"url": "https://github.com/naver/egjs-component/issues"
 	},
 	"homepage": "https://naver.github.io/egjs-component",
+	"files": [
+		"./*",
+		"declaration/*",
+		"dist/*"
+	],
 	"devDependencies": {
 		"@daybrush/jsdoc": "^0.3.8",
 		"@egjs/build-helper": "^0.1.2",


### PR DESCRIPTION
## Details
This adds the files field of package.json.
It prevents an issue with folders like `declarations` not being included in our package in certain deploy environments.